### PR TITLE
Remove requirement for IDs

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -118,9 +118,9 @@ router.get('/organisation/', function (req, res)
 /*
   - - - - - - - - - -  PROJECT PAGE - - - - - - - - - -
 */
-router.get('/projects/:id/:slug', function (req, res)
+router.get('/projects/:slug', function (req, res)
 {
-  var data = _.findWhere(req.app.locals.data, {id:parseInt(req.params.id)});
+  var data = _.findWhere(req.app.locals.data, {slug:req.params.slug});
   res.render('project', {
     "data":data,
     "phase_order":phase_order,
@@ -130,10 +130,10 @@ router.get('/projects/:id/:slug', function (req, res)
 /*
   - - - - - - - - - -  PROTOTYPE REDRIECT - - - - - - - - - -
 */
-router.get('/projects/:id/:slug/prototype', function (req, res)
+router.get('/projects/:slug/prototype', function (req, res)
 {
   var id = req.params.id;
-  var data = _.findWhere(req.app.locals.data, {id:parseInt(id)});
+  var data = _.findWhere(req.app.locals.data, {slug: req.params.slug});
   if (typeof data.prototype == 'undefined')
   {
     res.render('no-prototype',{

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -78,13 +78,13 @@
 
 				<ul class="link-list border-{{phase}}">
 				{% for bit in item[phase]['user'] %}
-					<li><a href="/projects/{{ bit.id }}/{{ bit.name | slugify }}">{{ bit.name }}</a></li>
+					<li><a href="/projects/{{ bit.slug }}">{{ bit.name }}</a></li>
 				{% endfor %}
 				</ul>
 
 				<ul class="link-list border-internal">
 				{% for bit in item[phase]['internal'] %}
-					<li><a href="/projects/{{ bit.id }}/{{ bit.name | slugify }}">{{ bit.name }}</a></li>
+					<li><a href="/projects/{{ bit.slug }}">{{ bit.name }}</a></li>
 				{% endfor %}
 				</ul>
 

--- a/server.js
+++ b/server.js
@@ -26,6 +26,7 @@ _.each(files,function(el)
   try {
     var json = merge(true,defaults,JSON.parse(file));
     json.filename = el;
+    json.slug = el.replace('.json', '');
     app.locals.data.push(json);
   } catch(err) {
     console.log(el, err);


### PR DESCRIPTION
This removes the requirement to have unique numerical IDs per project, by relying upon the unique filenames for the `.json` files within `/lib/project` instead.

This is a good idea, I think, as it removes the potential for accidental ID conflicts when different people write different Pull Requests to add projects at the same time (or for people to accidentally forget to add an ID altogether, as I did).  By relying on the filenames we can ensure that they are always present and always unique.

The downside to this is that it will break all the existing project URLs, which contain the IDs and a "slugified" version of the project name (which may or may not match the json filename).