### PR TITLE
Add Coronavirus support service

### DIFF
--- a/lib/projects/find-coronavirus-support.json
+++ b/lib/projects/find-coronavirus-support.json
@@ -1,0 +1,10 @@
+{
+  "name" : "Find out what support you can get if you’re affected by coronavirus",
+  "description": "Use this service to find out what help and advice you can get from the government and other organisations. You can use it for yourself or someone else.",
+  "organisation": "Government Digital Service",
+  "theme": "Benefits",
+  "phase":"unknown",
+  "liveservice":"https://find-coronavirus-support.service.gov.uk/need-help-with",
+  "start-page": "https://www.gov.uk/find-coronavirus-support",
+  "github":"https://github.com/alphagov/govuk-coronavirus-find-support"
+}


### PR DESCRIPTION
Adds this service: https://www.gov.uk/find-coronavirus-support